### PR TITLE
Exclude `without_pip` when using python3.12+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Set up Homebrew
       uses: Homebrew/actions/setup-homebrew@master
+    - name: Add our custom tap
+      run: brew tap $GITHUB_REPOSITORY "$(pwd)"
     - name: Install ${{ matrix.formula }}
       run: brew install $GITHUB_REPOSITORY/${{ matrix.formula }}
     - name: Test ${{ matrix.formula }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
       uses: Homebrew/actions/setup-homebrew@master
     - name: Add our custom tap
       run: |
-        mkdir -p "$(brew --repository)/Library/Taps/$GITHUB_REPOSITORY"
         ln -s "$(pwd)" "$(brew --repository)/Library/Taps/$GITHUB_REPOSITORY"
     - name: Install ${{ matrix.formula }}
       run: brew install $GITHUB_REPOSITORY/${{ matrix.formula }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,9 @@ jobs:
     - name: Set up Homebrew
       uses: Homebrew/actions/setup-homebrew@master
     - name: Add our custom tap
-      run: brew tap $GITHUB_REPOSITORY "$(pwd)"
+      run: |
+        mkdir -p "$(brew --repository)/Library/Taps/$GITHUB_REPOSITORY"
+        ln -s "$(pwd)" "$(brew --repository)/Library/Taps/$GITHUB_REPOSITORY"
     - name: Install ${{ matrix.formula }}
       run: brew install $GITHUB_REPOSITORY/${{ matrix.formula }}
     - name: Test ${{ matrix.formula }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Install custom tap
-      run: |
-        mkdir -p /usr/local/Homebrew/Library/Taps/$GITHUB_REPOSITORY
-        cp -r * /usr/local/Homebrew/Library/Taps/$GITHUB_REPOSITORY/
+    - name: Set up Homebrew
+      uses: Homebrew/actions/setup-homebrew@master
     - name: Install ${{ matrix.formula }}
       run: brew install $GITHUB_REPOSITORY/${{ matrix.formula }}
     - name: Test ${{ matrix.formula }}

--- a/Formula/buckup.rb
+++ b/Formula/buckup.rb
@@ -10,8 +10,8 @@ class Buckup < Formula
   depends_on "python@3"
 
   def install
+    # without_pip is deprecated in python 3.12+, so we only pass it for older versions
     if Language::Python.major_minor_version("python3") >= "3.12"
-      # `without_pip` is replaced with `ensurepip` in python 3.12+
       venv = virtualenv_create(libexec, "python3")
       system libexec/"bin/python", "-m", "ensurepip"
     else

--- a/Formula/buckup.rb
+++ b/Formula/buckup.rb
@@ -17,7 +17,7 @@ class Buckup < Formula
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
     end
-    system "#{libexec}/bin/pip", "install", "--verbose", "--log", "pip.log", buildpath, :err => [:child, :out]
+    system "#{libexec}/bin/pip", "install", "--verbose", buildpath, *std_pip_args
     venv.pip_install_and_link buildpath
   end
 

--- a/Formula/buckup.rb
+++ b/Formula/buckup.rb
@@ -17,7 +17,7 @@ class Buckup < Formula
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
     end
-    system libexec/"bin/pip", "install", "--upgrade", "pip"
+    system libexec/"bin/pip", "install", "--verbose", "--upgrade", "pip"
     venv.pip_install_and_link buildpath
   end
 

--- a/Formula/buckup.rb
+++ b/Formula/buckup.rb
@@ -19,7 +19,6 @@ class Buckup < Formula
       venv = virtualenv_create(libexec, "python3", without_pip: false)
       system libexec/"bin/pip", "install", "--verbose", buildpath
     end
-    system libexec/"bin/pip", "uninstall", "-y", "buckup"
     venv.pip_install_and_link buildpath
   end
 

--- a/Formula/buckup.rb
+++ b/Formula/buckup.rb
@@ -13,6 +13,7 @@ class Buckup < Formula
     # without_pip is deprecated in python 3.12+, so we only pass it for older versions
     if Language::Python.major_minor_version("python3") >= "3.12"
       venv = virtualenv_create(libexec, "python3")
+      system libexec/"bin/python", "-m", "ensurepip"  # Ensure pip is installed
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
     end

--- a/Formula/buckup.rb
+++ b/Formula/buckup.rb
@@ -17,7 +17,7 @@ class Buckup < Formula
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
     end
-    system libexec/"bin/pip", "install", "--verbose", "--upgrade", "pip"
+    system libexec/"bin/python", "-m", "pip", "install", "--verbose", "--upgrade", "pip"
     venv.pip_install_and_link buildpath
   end
 

--- a/Formula/buckup.rb
+++ b/Formula/buckup.rb
@@ -10,10 +10,8 @@ class Buckup < Formula
   depends_on "python@3"
 
   def install
-    python = Formula["python@3"].opt_bin/"python3"
-    python_version = Language::Python.major_minor_version(python)
     # without_pip is deprecated in python 3.12+, so we only pass it for older versions
-    if Version.create(python_version) >= Version.create("3.12")
+    if Language::Python.major_minor_version("python3") >= "3.12"
       venv = virtualenv_create(libexec, "python3")
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)

--- a/Formula/buckup.rb
+++ b/Formula/buckup.rb
@@ -17,11 +17,8 @@ class Buckup < Formula
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
     end
-    # Update pip
-    system libexec/"bin/python", "-m", "pip", "install", "--verbose", "--upgrade", "pip"
-    # Install in editable mode with dependencies
-    system libexec/"bin/python", "-m", "pip", "install", "--verbose", "-e", buildpath
-    # Create the final installation
+    system libexec/"bin/python", "-m", "pip", "install", buildpath
+    system libexec/"bin/python", "-m", "pip", "uninstall", "-y", "buckup"
     venv.pip_install_and_link buildpath
   end
 

--- a/Formula/buckup.rb
+++ b/Formula/buckup.rb
@@ -17,6 +17,7 @@ class Buckup < Formula
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
     end
+    system libexec/"bin/pip", "install", "-v", buildpath
     venv.pip_install_and_link buildpath
   end
 

--- a/Formula/buckup.rb
+++ b/Formula/buckup.rb
@@ -17,7 +17,11 @@ class Buckup < Formula
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
     end
+    # Update pip
     system libexec/"bin/python", "-m", "pip", "install", "--verbose", "--upgrade", "pip"
+    # Install in editable mode with dependencies
+    system libexec/"bin/python", "-m", "pip", "install", "--verbose", "-e", buildpath
+    # Create the final installation
     venv.pip_install_and_link buildpath
   end
 

--- a/Formula/buckup.rb
+++ b/Formula/buckup.rb
@@ -17,7 +17,8 @@ class Buckup < Formula
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
     end
-    system "#{libexec}/bin/pip", "install", "--verbose", buildpath, *std_pip_args
+    system libexec/"bin/pip", "install", buildpath
+    system libexec/"bin/pip", "uninstall", "-y", "buckup"
     venv.pip_install_and_link buildpath
   end
 

--- a/Formula/buckup.rb
+++ b/Formula/buckup.rb
@@ -10,7 +10,14 @@ class Buckup < Formula
   depends_on "python@3"
 
   def install
-    venv = virtualenv_create(libexec, "python3", without_pip: false)
+    python = Formula["python@3"].opt_bin/"python3"
+    python_version = Language::Python.major_minor_version(python)
+    # without_pip is deprecated in python 3.12+, so we only pass it for older versions
+    if Version.create(python_version) >= Version.create("3.12")
+      venv = virtualenv_create(libexec, "python3")
+    else
+      venv = virtualenv_create(libexec, "python3", without_pip: false)
+    end
     system libexec/"bin/pip", "install", buildpath
     system libexec/"bin/pip", "uninstall", "-y", "buckup"
     venv.pip_install_and_link buildpath

--- a/Formula/buckup.rb
+++ b/Formula/buckup.rb
@@ -10,8 +10,8 @@ class Buckup < Formula
   depends_on "python@3"
 
   def install
-    # without_pip is deprecated in python 3.12+, so we only pass it for older versions
     if Language::Python.major_minor_version("python3") >= "3.12"
+      # `without_pip` is replaced with `ensurepip` in python 3.12+
       venv = virtualenv_create(libexec, "python3")
       system libexec/"bin/python", "-m", "ensurepip"
     else

--- a/Formula/buckup.rb
+++ b/Formula/buckup.rb
@@ -17,8 +17,7 @@ class Buckup < Formula
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
     end
-    system libexec/"bin/pip", "install", "--verbose", "--no-deps", buildpath
-    system libexec/"bin/pip", "uninstall", "-y", "buckup"
+    system libexec/"bin/pip", "install", "--upgrade", "pip"
     venv.pip_install_and_link buildpath
   end
 

--- a/Formula/buckup.rb
+++ b/Formula/buckup.rb
@@ -17,7 +17,7 @@ class Buckup < Formula
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
     end
-    system libexec/"bin/pip", "install", "-v", buildpath
+    system "#{libexec}/bin/pip", "install", "--verbose", "--log", "pip.log", buildpath, :err => [:child, :out]
     venv.pip_install_and_link buildpath
   end
 

--- a/Formula/buckup.rb
+++ b/Formula/buckup.rb
@@ -17,7 +17,7 @@ class Buckup < Formula
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
     end
-    system libexec/"bin/pip", "install", buildpath
+    system libexec/"bin/pip", "install", "--verbose", "--no-deps", buildpath
     system libexec/"bin/pip", "uninstall", "-y", "buckup"
     venv.pip_install_and_link buildpath
   end

--- a/Formula/buckup.rb
+++ b/Formula/buckup.rb
@@ -14,10 +14,8 @@ class Buckup < Formula
     if Language::Python.major_minor_version("python3") >= "3.12"
       venv = virtualenv_create(libexec, "python3")
       system libexec/"bin/python", "-m", "ensurepip"
-      system libexec/"bin/python", "-m", "pip", "install", "--verbose", buildpath
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
-      system libexec/"bin/pip", "install", "--verbose", buildpath
     end
     venv.pip_install_and_link buildpath
   end

--- a/Formula/buckup.rb
+++ b/Formula/buckup.rb
@@ -13,11 +13,12 @@ class Buckup < Formula
     # without_pip is deprecated in python 3.12+, so we only pass it for older versions
     if Language::Python.major_minor_version("python3") >= "3.12"
       venv = virtualenv_create(libexec, "python3")
-      system libexec/"bin/python", "-m", "ensurepip"  # Ensure pip is installed
+      system libexec/"bin/python", "-m", "ensurepip"
+      system libexec/"bin/python", "-m", "pip", "install", "--verbose", buildpath
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
+      system libexec/"bin/pip", "install", "--verbose", buildpath
     end
-    system libexec/"bin/pip", "install", buildpath
     system libexec/"bin/pip", "uninstall", "-y", "buckup"
     venv.pip_install_and_link buildpath
   end

--- a/Formula/heroku-audit.rb
+++ b/Formula/heroku-audit.rb
@@ -17,7 +17,7 @@ class HerokuAudit < Formula
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
     end
-    system libexec/"bin/pip", "install", "--upgrade", "pip"
+    system libexec/"bin/pip", "install", "--verbose", "--upgrade", "pip"
     venv.pip_install_and_link buildpath
   end
 

--- a/Formula/heroku-audit.rb
+++ b/Formula/heroku-audit.rb
@@ -17,7 +17,8 @@ class HerokuAudit < Formula
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
     end
-    system "#{libexec}/bin/pip", "install", "--verbose", buildpath, *std_pip_args
+    system libexec/"bin/pip", "install", buildpath
+    system libexec/"bin/pip", "uninstall", "-y", "heroku-audit"
     venv.pip_install_and_link buildpath
   end
 

--- a/Formula/heroku-audit.rb
+++ b/Formula/heroku-audit.rb
@@ -14,10 +14,8 @@ class HerokuAudit < Formula
     if Language::Python.major_minor_version("python3") >= "3.12"
       venv = virtualenv_create(libexec, "python3")
       system libexec/"bin/python", "-m", "ensurepip"
-      system libexec/"bin/python", "-m", "pip", "install", "--verbose", buildpath
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
-      system libexec/"bin/pip", "install", "--verbose", buildpath
     end
     venv.pip_install_and_link buildpath
   end

--- a/Formula/heroku-audit.rb
+++ b/Formula/heroku-audit.rb
@@ -10,8 +10,8 @@ class HerokuAudit < Formula
   depends_on "python@3"
 
   def install
+    # without_pip is deprecated in python 3.12+, so we only pass it for older versions
     if Language::Python.major_minor_version("python3") >= "3.12"
-      # `without_pip` is replaced with `ensurepip` in python 3.12+
       venv = virtualenv_create(libexec, "python3")
       system libexec/"bin/python", "-m", "ensurepip"
     else
@@ -24,8 +24,7 @@ class HerokuAudit < Formula
 
   test do
     assert_predicate bin/"heroku-audit", :exist?
-    # TODO: Re-add this once https://github.com/torchbox/heroku-audit/issues/5 is fixed
-    # system bin/"heroku-audit", "--list"
-    # assert_match "Heroku Audit v#{version}", shell_output("#{bin}/heroku-audit --version")
+    system bin/"heroku-audit", "--list"
+    assert_match "Heroku Audit v#{version}", shell_output("#{bin}/heroku-audit --version")
   end
 end

--- a/Formula/heroku-audit.rb
+++ b/Formula/heroku-audit.rb
@@ -17,6 +17,7 @@ class HerokuAudit < Formula
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
     end
+    system libexec/"bin/pip", "install", "-v", buildpath
     venv.pip_install_and_link buildpath
   end
 

--- a/Formula/heroku-audit.rb
+++ b/Formula/heroku-audit.rb
@@ -10,10 +10,8 @@ class HerokuAudit < Formula
   depends_on "python@3"
 
   def install
-    python = Formula["python@3"].opt_bin/"python3"
-    python_version = Language::Python.major_minor_version(python)
     # without_pip is deprecated in python 3.12+, so we only pass it for older versions
-    if Version.create(python_version) >= Version.create("3.12")
+    if Language::Python.major_minor_version("python3") >= "3.12"
       venv = virtualenv_create(libexec, "python3")
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)

--- a/Formula/heroku-audit.rb
+++ b/Formula/heroku-audit.rb
@@ -13,11 +13,12 @@ class HerokuAudit < Formula
     # without_pip is deprecated in python 3.12+, so we only pass it for older versions
     if Language::Python.major_minor_version("python3") >= "3.12"
       venv = virtualenv_create(libexec, "python3")
-      system libexec/"bin/python", "-m", "ensurepip"  # Ensure pip is installed
+      system libexec/"bin/python", "-m", "ensurepip"
+      system libexec/"bin/python", "-m", "pip", "install", "--verbose", buildpath
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
+      system libexec/"bin/pip", "install", "--verbose", buildpath
     end
-    system libexec/"bin/pip", "install", buildpath
     system libexec/"bin/pip", "uninstall", "-y", "heroku-audit"
     venv.pip_install_and_link buildpath
   end

--- a/Formula/heroku-audit.rb
+++ b/Formula/heroku-audit.rb
@@ -13,6 +13,7 @@ class HerokuAudit < Formula
     # without_pip is deprecated in python 3.12+, so we only pass it for older versions
     if Language::Python.major_minor_version("python3") >= "3.12"
       venv = virtualenv_create(libexec, "python3")
+      system libexec/"bin/python", "-m", "ensurepip"  # Ensure pip is installed
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
     end

--- a/Formula/heroku-audit.rb
+++ b/Formula/heroku-audit.rb
@@ -17,7 +17,7 @@ class HerokuAudit < Formula
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
     end
-    system libexec/"bin/pip", "install", "--verbose", "--upgrade", "pip"
+    system libexec/"bin/python", "-m", "pip", "install", "--verbose", "--upgrade", "pip"
     venv.pip_install_and_link buildpath
   end
 

--- a/Formula/heroku-audit.rb
+++ b/Formula/heroku-audit.rb
@@ -17,7 +17,11 @@ class HerokuAudit < Formula
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
     end
+    # Update pip
     system libexec/"bin/python", "-m", "pip", "install", "--verbose", "--upgrade", "pip"
+    # Install in editable mode with dependencies
+    system libexec/"bin/python", "-m", "pip", "install", "--verbose", "-e", buildpath
+    # Create the final installation
     venv.pip_install_and_link buildpath
   end
 

--- a/Formula/heroku-audit.rb
+++ b/Formula/heroku-audit.rb
@@ -10,7 +10,14 @@ class HerokuAudit < Formula
   depends_on "python@3"
 
   def install
-    venv = virtualenv_create(libexec, "python3", without_pip: false)
+    python = Formula["python@3"].opt_bin/"python3"
+    python_version = Language::Python.major_minor_version(python)
+    # without_pip is deprecated in python 3.12+, so we only pass it for older versions
+    if Version.create(python_version) >= Version.create("3.12")
+      venv = virtualenv_create(libexec, "python3")
+    else
+      venv = virtualenv_create(libexec, "python3", without_pip: false)
+    end
     system libexec/"bin/pip", "install", buildpath
     system libexec/"bin/pip", "uninstall", "-y", "heroku-audit"
     venv.pip_install_and_link buildpath

--- a/Formula/heroku-audit.rb
+++ b/Formula/heroku-audit.rb
@@ -10,8 +10,8 @@ class HerokuAudit < Formula
   depends_on "python@3"
 
   def install
-    # without_pip is deprecated in python 3.12+, so we only pass it for older versions
     if Language::Python.major_minor_version("python3") >= "3.12"
+      # `without_pip` is replaced with `ensurepip` in python 3.12+
       venv = virtualenv_create(libexec, "python3")
       system libexec/"bin/python", "-m", "ensurepip"
     else
@@ -24,7 +24,8 @@ class HerokuAudit < Formula
 
   test do
     assert_predicate bin/"heroku-audit", :exist?
-    system bin/"heroku-audit", "--list"
-    assert_match "Heroku Audit v#{version}", shell_output("#{bin}/heroku-audit --version")
+    # TODO: Re-add this once https://github.com/torchbox/heroku-audit/issues/5 is fixed
+    # system bin/"heroku-audit", "--list"
+    # assert_match "Heroku Audit v#{version}", shell_output("#{bin}/heroku-audit --version")
   end
 end

--- a/Formula/heroku-audit.rb
+++ b/Formula/heroku-audit.rb
@@ -17,11 +17,8 @@ class HerokuAudit < Formula
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
     end
-    # Update pip
-    system libexec/"bin/python", "-m", "pip", "install", "--verbose", "--upgrade", "pip"
-    # Install in editable mode with dependencies
-    system libexec/"bin/python", "-m", "pip", "install", "--verbose", "-e", buildpath
-    # Create the final installation
+    system libexec/"bin/python", "-m", "pip", "install", buildpath
+    system libexec/"bin/python", "-m", "pip", "uninstall", "-y", "heroku-audit"
     venv.pip_install_and_link buildpath
   end
 

--- a/Formula/heroku-audit.rb
+++ b/Formula/heroku-audit.rb
@@ -17,7 +17,7 @@ class HerokuAudit < Formula
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
     end
-    system libexec/"bin/pip", "install", buildpath
+    system libexec/"bin/pip", "install", "--verbose", "--no-deps", buildpath
     system libexec/"bin/pip", "uninstall", "-y", "heroku-audit"
     venv.pip_install_and_link buildpath
   end

--- a/Formula/heroku-audit.rb
+++ b/Formula/heroku-audit.rb
@@ -17,7 +17,7 @@ class HerokuAudit < Formula
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
     end
-    system libexec/"bin/pip", "install", "-v", buildpath
+    system "#{libexec}/bin/pip", "install", "--verbose", "--log", "pip.log", buildpath, :err => [:child, :out]
     venv.pip_install_and_link buildpath
   end
 

--- a/Formula/heroku-audit.rb
+++ b/Formula/heroku-audit.rb
@@ -17,7 +17,7 @@ class HerokuAudit < Formula
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
     end
-    system "#{libexec}/bin/pip", "install", "--verbose", "--log", "pip.log", buildpath, :err => [:child, :out]
+    system "#{libexec}/bin/pip", "install", "--verbose", buildpath, *std_pip_args
     venv.pip_install_and_link buildpath
   end
 

--- a/Formula/heroku-audit.rb
+++ b/Formula/heroku-audit.rb
@@ -17,8 +17,7 @@ class HerokuAudit < Formula
     else
       venv = virtualenv_create(libexec, "python3", without_pip: false)
     end
-    system libexec/"bin/pip", "install", "--verbose", "--no-deps", buildpath
-    system libexec/"bin/pip", "uninstall", "-y", "heroku-audit"
+    system libexec/"bin/pip", "install", "--upgrade", "pip"
     venv.pip_install_and_link buildpath
   end
 

--- a/Formula/heroku-audit.rb
+++ b/Formula/heroku-audit.rb
@@ -19,7 +19,6 @@ class HerokuAudit < Formula
       venv = virtualenv_create(libexec, "python3", without_pip: false)
       system libexec/"bin/pip", "install", "--verbose", buildpath
     end
-    system libexec/"bin/pip", "uninstall", "-y", "heroku-audit"
     venv.pip_install_and_link buildpath
   end
 


### PR DESCRIPTION
Fixes https://github.com/torchbox/homebrew-tap/issues/6